### PR TITLE
UHF-249: Basic page layout

### DIFF
--- a/conf/cmi/block.block.hdbt_local_actions.yml
+++ b/conf/cmi/block.block.hdbt_local_actions.yml
@@ -8,8 +8,8 @@ _core:
   default_config_hash: oWtzNhXovga4YEfFJHOgdTuYBbG9N6FzBYExs1i5Szc
 id: hdbt_local_actions
 theme: hdbt
-region: before_content
-weight: -4
+region: tools
+weight: -3
 provider: null
 plugin: local_actions_block
 settings:

--- a/conf/cmi/block.block.hdbt_local_tasks.yml
+++ b/conf/cmi/block.block.hdbt_local_tasks.yml
@@ -8,8 +8,8 @@ _core:
   default_config_hash: 7c3CoKhGNLjUHvFXo0rm2FcAdLUqy_kRgExJh6jWL4Q
 id: hdbt_local_tasks
 theme: hdbt
-region: before_content
-weight: -20
+region: tools
+weight: -4
 provider: null
 plugin: local_tasks_block
 settings:

--- a/conf/cmi/block.block.hdbt_tools.yml
+++ b/conf/cmi/block.block.hdbt_tools.yml
@@ -13,7 +13,7 @@ _core:
 id: hdbt_tools
 theme: hdbt
 region: tools
-weight: -3
+weight: -5
 provider: null
 plugin: 'system_menu_block:tools'
 settings:


### PR DESCRIPTION
UHF-249 Moved local tasks and actions to tools region on hdbt-theme

To test:

1. Switch to corresponding branch: `composer require drupal/hdbt:dev-UHF-249-basic-page-layout`
2. Run `make drush-cr`
3. Go to check that basic pages look good. Instructions are very similar to platform changes [here](https://github.com/City-of-Helsinki/drupal-hdbt/pull/32)