### PR TITLE
UHF-191 Image paragraph

### DIFF
--- a/conf/cmi/core.entity_form_display.media.image.default.yml
+++ b/conf/cmi/core.entity_form_display.media.image.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.media.image.field_media_image
+    - field.field.media.image.field_photographer
     - image.style.media_library
     - media.type.image
   module:
@@ -16,12 +17,12 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
   field_media_image:
-    weight: 0
+    weight: 1
     settings:
       preview_image_style: media_library
       progress_indicator: throbber
@@ -30,16 +31,24 @@ content:
     third_party_settings: {  }
     type: image_focal_point
     region: content
+  field_photographer:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   langcode:
     type: language_select
-    weight: 2
+    weight: 3
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   name:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -47,7 +56,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -55,17 +64,17 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 100
+    weight: 8
     region: content
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 4
     settings:
       match_operator: CONTAINS
       size: 60

--- a/conf/cmi/core.entity_form_display.media.image.media_library.yml
+++ b/conf/cmi/core.entity_form_display.media.image.media_library.yml
@@ -16,7 +16,7 @@ bundle: image
 mode: media_library
 content:
   field_media_image:
-    weight: 5
+    weight: 1
     settings:
       preview_image_style: media_library
       progress_indicator: throbber
@@ -25,6 +25,14 @@ content:
     third_party_settings: {  }
     type: image_focal_point
     region: content
+  field_photographer:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   name:
     type: string_textfield
     settings:
@@ -34,13 +42,12 @@ content:
     third_party_settings: {  }
     region: content
   translation:
-    weight: 10
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   created: true
-  field_photographer: true
   langcode: true
   path: true
   status: true

--- a/conf/cmi/core.entity_form_display.media.image.media_library.yml
+++ b/conf/cmi/core.entity_form_display.media.image.media_library.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_form_mode.media.media_library
     - field.field.media.image.field_media_image
+    - field.field.media.image.field_photographer
     - image.style.media_library
     - media.type.image
   module:
@@ -39,6 +40,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_photographer: true
   langcode: true
   path: true
   status: true

--- a/conf/cmi/core.entity_form_display.paragraph.image.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.image.default.yml
@@ -1,0 +1,41 @@
+uuid: c1d43769-0c73-4740-9618-60d40251765c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.image.field_image
+    - field.field.paragraph.image.field_image_caption
+    - field.field.paragraph.image.field_original_aspect_ratio
+    - paragraphs.paragraphs_type.image
+  module:
+    - media_library
+id: paragraph.image.default
+targetEntityType: paragraph
+bundle: image
+mode: default
+content:
+  field_image:
+    type: media_library_widget
+    weight: 0
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+  field_image_caption:
+    weight: 1
+    settings:
+      rows: 2
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_original_aspect_ratio:
+    weight: 2
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+hidden:
+  created: true
+  status: true

--- a/conf/cmi/core.entity_form_display.paragraph.list_of_links.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.list_of_links.default.yml
@@ -21,15 +21,22 @@ content:
     type: options_select
     region: content
   field_list_of_links_links:
-    type: entity_reference_paragraphs
+    type: paragraphs
     weight: 2
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed_expand_nested
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: list_of_links_item
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
     third_party_settings: {  }
     region: content
   field_list_of_links_title:

--- a/conf/cmi/core.entity_view_display.media.image.image.yml
+++ b/conf/cmi/core.entity_view_display.media.image.image.yml
@@ -1,31 +1,39 @@
-uuid: 458f69f3-b20c-4949-8e6d-a8caf274c3af
+uuid: 44e4252b-235b-431f-b9fb-8222932bc2bd
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.image
     - field.field.media.image.field_media_image
     - field.field.media.image.field_photographer
-    - image.style.large
     - media.type.image
+    - responsive_image.styles.original
   module:
-    - image
-id: media.image.default
+    - responsive_image
+id: media.image.image
 targetEntityType: media
 bundle: image
-mode: default
+mode: image
 content:
   field_media_image:
     label: hidden
     weight: 0
     settings:
-      image_style: large
+      responsive_image_style: original
       image_link: ''
     third_party_settings: {  }
-    type: image
+    type: responsive_image
     region: content
+  field_photographer:
+    type: string
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
 hidden:
   created: true
-  field_photographer: true
   langcode: true
   name: true
   thumbnail: true

--- a/conf/cmi/core.entity_view_display.media.image.list_of_links.yml
+++ b/conf/cmi/core.entity_view_display.media.image.list_of_links.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.list_of_links
     - field.field.media.image.field_media_image
+    - field.field.media.image.field_photographer
     - media.type.image
     - responsive_image.styles.list_of_links__thumbnail
   module:
@@ -25,6 +26,7 @@ content:
     region: content
 hidden:
   created: true
+  field_photographer: true
   langcode: true
   name: true
   thumbnail: true

--- a/conf/cmi/core.entity_view_display.media.image.media_library.yml
+++ b/conf/cmi/core.entity_view_display.media.image.media_library.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.media_library
     - field.field.media.image.field_media_image
+    - field.field.media.image.field_photographer
     - image.style.medium
     - media.type.image
   module:
@@ -26,6 +27,7 @@ content:
 hidden:
   created: true
   field_media_image: true
+  field_photographer: true
   langcode: true
   name: true
   uid: true

--- a/conf/cmi/core.entity_view_display.paragraph.image.default.yml
+++ b/conf/cmi/core.entity_view_display.paragraph.image.default.yml
@@ -1,0 +1,41 @@
+uuid: 649acd45-1db6-4f92-971a-a8b8593de2ce
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.image.field_image
+    - field.field.paragraph.image.field_image_caption
+    - field.field.paragraph.image.field_original_aspect_ratio
+    - paragraphs.paragraphs_type.image
+id: paragraph.image.default
+targetEntityType: paragraph
+bundle: image
+mode: default
+content:
+  field_image:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: image
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_image_caption:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_original_aspect_ratio:
+    type: boolean
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      format: default
+      format_custom_true: ''
+      format_custom_false: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/conf/cmi/core.entity_view_mode.media.image.yml
+++ b/conf/cmi/core.entity_view_mode.media.image.yml
@@ -1,0 +1,10 @@
+uuid: 8f200b8d-601d-4494-9b4d-8a3839830ef2
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.image
+label: Image
+targetEntityType: media
+cache: true

--- a/conf/cmi/field.field.media.image.field_photographer.yml
+++ b/conf/cmi/field.field.media.image.field_photographer.yml
@@ -1,0 +1,19 @@
+uuid: cf1302ba-5c57-4bf8-aef1-4b3be024fa82
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_photographer
+    - media.type.image
+id: media.image.field_photographer
+field_name: field_photographer
+entity_type: media
+bundle: image
+label: Photographer
+description: 'Write here the name of the photographer of the image.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.article.field_content.yml
+++ b/conf/cmi/field.field.node.article.field_content.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_content
     - node.type.article
+    - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.link
     - paragraphs.paragraphs_type.text
   module:
@@ -26,13 +27,23 @@ settings:
     target_bundles:
       link: link
       text: text
+      image: image
     target_bundles_drag_drop:
       hero:
         weight: 4
         enabled: false
+      image:
+        enabled: true
+        weight: 7
       link:
         enabled: true
         weight: 5
+      list_of_links:
+        weight: 10
+        enabled: false
+      list_of_links_item:
+        weight: 11
+        enabled: false
       text:
         enabled: true
         weight: 6

--- a/conf/cmi/field.field.node.page.field_content.yml
+++ b/conf/cmi/field.field.node.page.field_content.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_content
     - node.type.page
+    - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.link
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.text
@@ -27,17 +28,24 @@ settings:
     target_bundles:
       link: link
       text: text
+      image: image
       list_of_links: list_of_links
     target_bundles_drag_drop:
       hero:
         weight: 4
         enabled: false
+      image:
+        enabled: true
+        weight: 7
       link:
         enabled: true
         weight: 5
       list_of_links:
         enabled: true
         weight: 7
+      list_of_links_item:
+        weight: 11
+        enabled: false
       text:
         enabled: true
         weight: 6

--- a/conf/cmi/field.field.paragraph.image.field_image.yml
+++ b/conf/cmi/field.field.paragraph.image.field_image.yml
@@ -1,0 +1,29 @@
+uuid: 4ca33926-85dd-4826-b01b-38aa3d4d67e8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_image
+    - media.type.image
+    - paragraphs.paragraphs_type.image
+id: paragraph.image.field_image
+field_name: field_image
+entity_type: paragraph
+bundle: image
+label: 'Image file'
+description: 'Add the image file that you want to use from media-library.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/cmi/field.field.paragraph.image.field_image_caption.yml
+++ b/conf/cmi/field.field.paragraph.image.field_image_caption.yml
@@ -1,0 +1,19 @@
+uuid: b076a736-5b05-4bf8-827d-5845fa822618
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_image_caption
+    - paragraphs.paragraphs_type.image
+id: paragraph.image.field_image_caption
+field_name: field_image_caption
+entity_type: paragraph
+bundle: image
+label: Caption
+description: 'You can provide a caption for the image here.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/conf/cmi/field.field.paragraph.image.field_original_aspect_ratio.yml
+++ b/conf/cmi/field.field.paragraph.image.field_original_aspect_ratio.yml
@@ -1,0 +1,23 @@
+uuid: aa1d636e-04ee-4378-b9c0-c9f958a9880b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_original_aspect_ratio
+    - paragraphs.paragraphs_type.image
+id: paragraph.image.field_original_aspect_ratio
+field_name: field_original_aspect_ratio
+entity_type: paragraph
+bundle: image
+label: 'Use original aspect ratio'
+description: 'If you have to use the original aspect ratio of the image you can do so by choosing this option. However it is recommended to let the system crop your image so that it will look balanced on the page.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'true'
+  off_label: 'false'
+field_type: boolean

--- a/conf/cmi/field.storage.media.field_photographer.yml
+++ b/conf/cmi/field.storage.media.field_photographer.yml
@@ -1,0 +1,21 @@
+uuid: 63965fcc-6fe1-4bab-8cee-f74016fbe93e
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_photographer
+field_name: field_photographer
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.paragraph.field_image.yml
+++ b/conf/cmi/field.storage.paragraph.field_image.yml
@@ -1,0 +1,20 @@
+uuid: 3ad28c55-cfc6-4f0f-a943-8214791aec7e
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - paragraphs
+id: paragraph.field_image
+field_name: field_image
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.paragraph.field_image_caption.yml
+++ b/conf/cmi/field.storage.paragraph.field_image_caption.yml
@@ -1,0 +1,19 @@
+uuid: c1633807-1bb8-4372-b907-ebde9f61288c
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_image_caption
+field_name: field_image_caption
+entity_type: paragraph
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.paragraph.field_original_aspect_ratio.yml
+++ b/conf/cmi/field.storage.paragraph.field_original_aspect_ratio.yml
@@ -1,0 +1,18 @@
+uuid: ec012c8b-c7c4-421b-824a-aae9e84e0fab
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_original_aspect_ratio
+field_name: field_original_aspect_ratio
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/image.style.1_1_l_2x.yml
+++ b/conf/cmi/image.style.1_1_l_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.1_1_m_2x.yml
+++ b/conf/cmi/image.style.1_1_m_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.1_1_s_2x.yml
+++ b/conf/cmi/image.style.1_1_s_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.1_1_xl_2x.yml
+++ b/conf/cmi/image.style.1_1_xl_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.1_1_xs_2x.yml
+++ b/conf/cmi/image.style.1_1_xs_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.23_10_l_2x.yml
+++ b/conf/cmi/image.style.23_10_l_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.23_10_m_2x.yml
+++ b/conf/cmi/image.style.23_10_m_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.23_10_s_2x.yml
+++ b/conf/cmi/image.style.23_10_s_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.23_10_xl_2x.yml
+++ b/conf/cmi/image.style.23_10_xl_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.23_10_xs_2x.yml
+++ b/conf/cmi/image.style.23_10_xs_2x.yml
@@ -21,4 +21,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.3_2_l_2x.yml
+++ b/conf/cmi/image.style.3_2_l_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.3_2_m_2x.yml
+++ b/conf/cmi/image.style.3_2_m_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.3_2_s_2x.yml
+++ b/conf/cmi/image.style.3_2_s_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.3_2_xl_2x.yml
+++ b/conf/cmi/image.style.3_2_xl_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.3_2_xs_2x.yml
+++ b/conf/cmi/image.style.3_2_xs_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.3_2_xxs.yml
+++ b/conf/cmi/image.style.3_2_xxs.yml
@@ -1,0 +1,17 @@
+uuid: 2c1033c9-378d-418a-b710-206bf62c92b5
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: 3_2_xxs
+label: '3:2 XXS'
+effects:
+  6bc1f53e-970d-4a85-a1a0-c41af5f5834b:
+    uuid: 6bc1f53e-970d-4a85-a1a0-c41af5f5834b
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 320
+      height: 213
+      crop_type: focal_point

--- a/conf/cmi/image.style.3_2_xxs_2x.yml
+++ b/conf/cmi/image.style.3_2_xxs_2x.yml
@@ -21,4 +21,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.3_2_xxs_2x.yml
+++ b/conf/cmi/image.style.3_2_xxs_2x.yml
@@ -1,0 +1,24 @@
+uuid: 371a111c-f7eb-4175-b2d1-4e1341377fc3
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+    - image_style_quality
+name: 3_2_xxs_2x
+label: '3:2 XXS (2x)'
+effects:
+  04ed67a0-ed4c-4b01-b5be-cee1205f62d8:
+    uuid: 04ed67a0-ed4c-4b01-b5be-cee1205f62d8
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 640
+      height: 427
+      crop_type: focal_point
+  e7aa43d0-465e-4fd2-b3bd-c5cfa976bdd0:
+    uuid: e7aa43d0-465e-4fd2-b3bd-c5cfa976bdd0
+    id: image_style_quality
+    weight: 2
+    data:
+      quality: 35

--- a/conf/cmi/image.style.original_l.yml
+++ b/conf/cmi/image.style.original_l.yml
@@ -1,0 +1,15 @@
+uuid: 92304495-995a-44f8-b423-138cdaffb61e
+langcode: fi
+status: true
+dependencies: {  }
+name: original_l
+label: 'Original L'
+effects:
+  0c465a35-1ef2-4e25-b6a9-30b461a5f89d:
+    uuid: 0c465a35-1ef2-4e25-b6a9-30b461a5f89d
+    id: image_scale
+    weight: 1
+    data:
+      width: 996
+      height: null
+      upscale: true

--- a/conf/cmi/image.style.original_l.yml
+++ b/conf/cmi/image.style.original_l.yml
@@ -1,5 +1,5 @@
 uuid: 92304495-995a-44f8-b423-138cdaffb61e
-langcode: fi
+langcode: en
 status: true
 dependencies: {  }
 name: original_l

--- a/conf/cmi/image.style.original_l.yml
+++ b/conf/cmi/image.style.original_l.yml
@@ -10,6 +10,6 @@ effects:
     id: image_scale
     weight: 1
     data:
-      width: 996
+      width: 1200
       height: null
       upscale: true

--- a/conf/cmi/image.style.original_l_2x.yml
+++ b/conf/cmi/image.style.original_l_2x.yml
@@ -1,0 +1,23 @@
+uuid: c1963fd0-fc3d-47c8-899c-22524bb121a3
+langcode: fi
+status: true
+dependencies:
+  module:
+    - image_style_quality
+name: original_l_2x
+label: 'Original L (2x)'
+effects:
+  0249bded-7547-49ab-b241-4d6f8b6973f6:
+    uuid: 0249bded-7547-49ab-b241-4d6f8b6973f6
+    id: image_scale
+    weight: 1
+    data:
+      width: 1992
+      height: null
+      upscale: true
+  b80b3bcc-ae09-4126-8c1d-af47b9390cf8:
+    uuid: b80b3bcc-ae09-4126-8c1d-af47b9390cf8
+    id: image_style_quality
+    weight: 2
+    data:
+      quality: 35

--- a/conf/cmi/image.style.original_l_2x.yml
+++ b/conf/cmi/image.style.original_l_2x.yml
@@ -12,7 +12,7 @@ effects:
     id: image_scale
     weight: 1
     data:
-      width: 1992
+      width: 2400
       height: null
       upscale: true
   b80b3bcc-ae09-4126-8c1d-af47b9390cf8:
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.original_l_2x.yml
+++ b/conf/cmi/image.style.original_l_2x.yml
@@ -1,5 +1,5 @@
 uuid: c1963fd0-fc3d-47c8-899c-22524bb121a3
-langcode: fi
+langcode: en
 status: true
 dependencies:
   module:

--- a/conf/cmi/image.style.original_m.yml
+++ b/conf/cmi/image.style.original_m.yml
@@ -1,0 +1,15 @@
+uuid: 0d5d3c57-f183-4909-ba1b-20a0662c0c5e
+langcode: fi
+status: true
+dependencies: {  }
+name: original_m
+label: 'Original M'
+effects:
+  d223a0ce-9eaa-472d-89ef-d1d82b407a66:
+    uuid: d223a0ce-9eaa-472d-89ef-d1d82b407a66
+    id: image_scale
+    weight: 1
+    data:
+      width: 943
+      height: null
+      upscale: true

--- a/conf/cmi/image.style.original_m.yml
+++ b/conf/cmi/image.style.original_m.yml
@@ -1,5 +1,5 @@
 uuid: 0d5d3c57-f183-4909-ba1b-20a0662c0c5e
-langcode: fi
+langcode: en
 status: true
 dependencies: {  }
 name: original_m

--- a/conf/cmi/image.style.original_m_2x.yml
+++ b/conf/cmi/image.style.original_m_2x.yml
@@ -1,0 +1,23 @@
+uuid: 456b8cfc-8b1b-4f34-8844-a78cdd4b6a4a
+langcode: fi
+status: true
+dependencies:
+  module:
+    - image_style_quality
+name: original_m_2x
+label: 'Original M (2x)'
+effects:
+  030a8bc9-6a90-44d4-b920-691c51ace740:
+    uuid: 030a8bc9-6a90-44d4-b920-691c51ace740
+    id: image_scale
+    weight: 1
+    data:
+      width: 1886
+      height: null
+      upscale: true
+  02e23d47-dd80-431b-a22e-a9799489208e:
+    uuid: 02e23d47-dd80-431b-a22e-a9799489208e
+    id: image_style_quality
+    weight: 2
+    data:
+      quality: 35

--- a/conf/cmi/image.style.original_m_2x.yml
+++ b/conf/cmi/image.style.original_m_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.original_m_2x.yml
+++ b/conf/cmi/image.style.original_m_2x.yml
@@ -1,5 +1,5 @@
 uuid: 456b8cfc-8b1b-4f34-8844-a78cdd4b6a4a
-langcode: fi
+langcode: en
 status: true
 dependencies:
   module:

--- a/conf/cmi/image.style.original_s.yml
+++ b/conf/cmi/image.style.original_s.yml
@@ -1,0 +1,15 @@
+uuid: 6e26eabc-2aaa-4e68-9921-66c724dd0123
+langcode: fi
+status: true
+dependencies: {  }
+name: original_s
+label: 'Original S'
+effects:
+  409c7a0a-40f8-4f01-a20d-28fce5e24ed1:
+    uuid: 409c7a0a-40f8-4f01-a20d-28fce5e24ed1
+    id: image_scale
+    weight: 1
+    data:
+      width: 768
+      height: null
+      upscale: true

--- a/conf/cmi/image.style.original_s.yml
+++ b/conf/cmi/image.style.original_s.yml
@@ -1,5 +1,5 @@
 uuid: 6e26eabc-2aaa-4e68-9921-66c724dd0123
-langcode: fi
+langcode: en
 status: true
 dependencies: {  }
 name: original_s

--- a/conf/cmi/image.style.original_s_2x.yml
+++ b/conf/cmi/image.style.original_s_2x.yml
@@ -1,0 +1,23 @@
+uuid: a69079d7-e2df-4491-9590-f43a1c59ae33
+langcode: fi
+status: true
+dependencies:
+  module:
+    - image_style_quality
+name: original_s_2x
+label: 'Original S (2x)'
+effects:
+  4a8a2af8-c602-444e-9d0d-9ae25bdc428a:
+    uuid: 4a8a2af8-c602-444e-9d0d-9ae25bdc428a
+    id: image_scale
+    weight: 1
+    data:
+      width: 1535
+      height: null
+      upscale: true
+  9dc8ae09-bca0-4c20-81ce-3324078d1084:
+    uuid: 9dc8ae09-bca0-4c20-81ce-3324078d1084
+    id: image_style_quality
+    weight: 2
+    data:
+      quality: 35

--- a/conf/cmi/image.style.original_s_2x.yml
+++ b/conf/cmi/image.style.original_s_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.original_s_2x.yml
+++ b/conf/cmi/image.style.original_s_2x.yml
@@ -1,5 +1,5 @@
 uuid: a69079d7-e2df-4491-9590-f43a1c59ae33
-langcode: fi
+langcode: en
 status: true
 dependencies:
   module:

--- a/conf/cmi/image.style.original_xs.yml
+++ b/conf/cmi/image.style.original_xs.yml
@@ -1,5 +1,5 @@
 uuid: 7c81cc92-038f-4bf7-9d55-8ab5600f8c97
-langcode: fi
+langcode: en
 status: true
 dependencies: {  }
 name: original_xs

--- a/conf/cmi/image.style.original_xs.yml
+++ b/conf/cmi/image.style.original_xs.yml
@@ -1,0 +1,15 @@
+uuid: 7c81cc92-038f-4bf7-9d55-8ab5600f8c97
+langcode: fi
+status: true
+dependencies: {  }
+name: original_xs
+label: 'Original XS'
+effects:
+  41feb5a7-5a5f-432f-a6f4-ef53ae096713:
+    uuid: 41feb5a7-5a5f-432f-a6f4-ef53ae096713
+    id: image_scale
+    weight: 1
+    data:
+      width: 576
+      height: null
+      upscale: true

--- a/conf/cmi/image.style.original_xs_2x.yml
+++ b/conf/cmi/image.style.original_xs_2x.yml
@@ -1,0 +1,23 @@
+uuid: 55f0dd62-d390-430b-b301-4721d777b9f6
+langcode: fi
+status: true
+dependencies:
+  module:
+    - image_style_quality
+name: original_xs_2x
+label: 'Original XS (2x)'
+effects:
+  a3a2adef-0ea9-4dc0-93bc-f9e1bb2a2545:
+    uuid: a3a2adef-0ea9-4dc0-93bc-f9e1bb2a2545
+    id: image_scale
+    weight: 1
+    data:
+      width: 1152
+      height: null
+      upscale: true
+  1d56f6dd-eff0-4213-95ea-6304b0dddb20:
+    uuid: 1d56f6dd-eff0-4213-95ea-6304b0dddb20
+    id: image_style_quality
+    weight: 2
+    data:
+      quality: 35

--- a/conf/cmi/image.style.original_xs_2x.yml
+++ b/conf/cmi/image.style.original_xs_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.original_xs_2x.yml
+++ b/conf/cmi/image.style.original_xs_2x.yml
@@ -1,5 +1,5 @@
 uuid: 55f0dd62-d390-430b-b301-4721d777b9f6
-langcode: fi
+langcode: en
 status: true
 dependencies:
   module:

--- a/conf/cmi/image.style.original_xxs.yml
+++ b/conf/cmi/image.style.original_xxs.yml
@@ -1,0 +1,15 @@
+uuid: 17155d01-fe51-4373-9178-ffc4dbc290e1
+langcode: fi
+status: true
+dependencies: {  }
+name: original_xxs
+label: 'Original XXS'
+effects:
+  414ab756-ad1e-443d-9818-065d764efefc:
+    uuid: 414ab756-ad1e-443d-9818-065d764efefc
+    id: image_scale
+    weight: 1
+    data:
+      width: 320
+      height: null
+      upscale: true

--- a/conf/cmi/image.style.original_xxs.yml
+++ b/conf/cmi/image.style.original_xxs.yml
@@ -1,5 +1,5 @@
 uuid: 17155d01-fe51-4373-9178-ffc4dbc290e1
-langcode: fi
+langcode: en
 status: true
 dependencies: {  }
 name: original_xxs

--- a/conf/cmi/image.style.original_xxs_2x.yml
+++ b/conf/cmi/image.style.original_xxs_2x.yml
@@ -20,4 +20,4 @@ effects:
     id: image_style_quality
     weight: 2
     data:
-      quality: 35
+      quality: 65

--- a/conf/cmi/image.style.original_xxs_2x.yml
+++ b/conf/cmi/image.style.original_xxs_2x.yml
@@ -1,5 +1,5 @@
 uuid: 74bc2d78-3b63-4f6e-9b17-742dd16dbacd
-langcode: fi
+langcode: en
 status: true
 dependencies:
   module:

--- a/conf/cmi/image.style.original_xxs_2x.yml
+++ b/conf/cmi/image.style.original_xxs_2x.yml
@@ -1,0 +1,23 @@
+uuid: 74bc2d78-3b63-4f6e-9b17-742dd16dbacd
+langcode: fi
+status: true
+dependencies:
+  module:
+    - image_style_quality
+name: original_xxs_2x
+label: 'Original XXS (2x)'
+effects:
+  c96a6172-5713-4b5c-ab12-fe821d715ddb:
+    uuid: c96a6172-5713-4b5c-ab12-fe821d715ddb
+    id: image_scale
+    weight: 1
+    data:
+      width: 640
+      height: null
+      upscale: true
+  ad88bb2e-9122-43b0-aa76-8b8a463e8a27:
+    uuid: ad88bb2e-9122-43b0-aa76-8b8a463e8a27
+    id: image_style_quality
+    weight: 2
+    data:
+      quality: 35

--- a/conf/cmi/language/fi/field.field.media.image.field_photographer.yml
+++ b/conf/cmi/language/fi/field.field.media.image.field_photographer.yml
@@ -1,0 +1,2 @@
+label: Kuvaaja
+description: 'Kirjoita tähän kuvaajan nimi.'

--- a/conf/cmi/language/fi/field.field.paragraph.image.field_image.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.image.field_image.yml
@@ -1,0 +1,2 @@
+label: Kuvatiedosto
+description: 'Lisää haluamasi kuvatiedosto tähän media-kirjastosta.'

--- a/conf/cmi/language/fi/field.field.paragraph.image.field_image_caption.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.image.field_image_caption.yml
@@ -1,0 +1,2 @@
+label: Kuvateksti
+description: 'Voit halutessasi kirjoittaa kuvatekstin kuvalle tähän.'

--- a/conf/cmi/language/fi/field.field.paragraph.image.field_original_aspect_ratio.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.image.field_original_aspect_ratio.yml
@@ -1,0 +1,2 @@
+label: 'Käytä alkuperäistä kuvasuhdetta'
+description: 'Jos sinun on käytettävä kuvan alkuperäistä kuvasuhdetta voit tehdä sen valitsemalla tämän. On kuitenkin suositeltavaa antaa järjestelmän skaalata ja leikata kuvasi jotta sisältö näyttää tasapainoiselta.'

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.image.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.image.yml
@@ -1,0 +1,2 @@
+label: Kuva
+description: 'Kuva kuvatekstillä'

--- a/conf/cmi/paragraphs.paragraphs_type.image.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.image.yml
@@ -1,0 +1,10 @@
+uuid: d2d6693e-d293-4efc-9710-07c96dacd3cd
+langcode: en
+status: true
+dependencies: {  }
+id: image
+label: Image
+icon_uuid: null
+icon_default: null
+description: 'Image with a caption'
+behavior_plugins: {  }

--- a/conf/cmi/responsive_image.styles.image__3_2.yml
+++ b/conf/cmi/responsive_image.styles.image__3_2.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - image.style.3_2_l
+    - image.style.3_2_l_2x
     - image.style.3_2_m
     - image.style.3_2_m_2x
     - image.style.3_2_s
@@ -16,6 +18,16 @@ dependencies:
 id: image__3_2
 label: 'Image 3:2'
 image_style_mappings:
+  -
+    breakpoint_id: hdbt.l
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: 3_2_l
+  -
+    breakpoint_id: hdbt.l
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: 3_2_l_2x
   -
     breakpoint_id: hdbt.m
     multiplier: 1x

--- a/conf/cmi/responsive_image.styles.image__3_2.yml
+++ b/conf/cmi/responsive_image.styles.image__3_2.yml
@@ -1,0 +1,60 @@
+uuid: 10b7b45f-98bc-426e-8299-1af5f35ff72d
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.3_2_m
+    - image.style.3_2_m_2x
+    - image.style.3_2_s
+    - image.style.3_2_s_2x
+    - image.style.3_2_xs
+    - image.style.3_2_xs_2x
+    - image.style.3_2_xxs
+    - image.style.3_2_xxs_2x
+  theme:
+    - hdbt
+id: image__3_2
+label: 'Image 3:2'
+image_style_mappings:
+  -
+    breakpoint_id: hdbt.m
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: 3_2_m
+  -
+    breakpoint_id: hdbt.m
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: 3_2_m_2x
+  -
+    breakpoint_id: hdbt.s
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: 3_2_s
+  -
+    breakpoint_id: hdbt.s
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: 3_2_s_2x
+  -
+    breakpoint_id: hdbt.xs
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: 3_2_xs
+  -
+    breakpoint_id: hdbt.xs
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: 3_2_xs_2x
+  -
+    breakpoint_id: hdbt.xxs
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: 3_2_xxs
+  -
+    breakpoint_id: hdbt.xxs
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: 3_2_xxs_2x
+breakpoint_group: hdbt
+fallback_image_style: 3_2_m

--- a/conf/cmi/responsive_image.styles.original.yml
+++ b/conf/cmi/responsive_image.styles.original.yml
@@ -1,5 +1,5 @@
 uuid: 6761c512-9232-4b61-b74d-51e700138a17
-langcode: fi
+langcode: en
 status: true
 dependencies:
   config:

--- a/conf/cmi/responsive_image.styles.original.yml
+++ b/conf/cmi/responsive_image.styles.original.yml
@@ -1,0 +1,72 @@
+uuid: 6761c512-9232-4b61-b74d-51e700138a17
+langcode: fi
+status: true
+dependencies:
+  config:
+    - image.style.original_l
+    - image.style.original_l_2x
+    - image.style.original_m
+    - image.style.original_m_2x
+    - image.style.original_s
+    - image.style.original_s_2x
+    - image.style.original_xs
+    - image.style.original_xs_2x
+    - image.style.original_xxs
+    - image.style.original_xxs_2x
+  theme:
+    - hdbt
+id: original
+label: Original
+image_style_mappings:
+  -
+    breakpoint_id: hdbt.l
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: original_l
+  -
+    breakpoint_id: hdbt.l
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: original_l_2x
+  -
+    breakpoint_id: hdbt.m
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: original_m
+  -
+    breakpoint_id: hdbt.m
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: original_m_2x
+  -
+    breakpoint_id: hdbt.s
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: original_s
+  -
+    breakpoint_id: hdbt.s
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: original_s_2x
+  -
+    breakpoint_id: hdbt.xs
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: original_xs
+  -
+    breakpoint_id: hdbt.xs
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: original_xs_2x
+  -
+    breakpoint_id: hdbt.xxs
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: original_xxs
+  -
+    breakpoint_id: hdbt.xxs
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: original_xxs_2x
+breakpoint_group: hdbt
+fallback_image_style: original_l


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- Switch to corresponding branches: 
   - `composer require drupal/hdbt:dev-UHF-191-image-paragraph && composer require drupal/helfi_platform_config:dev-UHF-191-image-paragraph`
- Run `make new`
- Go to edit any example content and make sure you can add "Image" paragraph. The paragraph should have possibility to add caption and use original aspect ratio of the image. If you upload a new image you should also now have possibility to write photographer to the image when uploading or editing the node in the media library. Make sure when using Finnish UI that the fields are translated.
- Make sure there is test content here:
- https://hel-platform.docker.sh/fi/helsingin-kaupunginosat
- https://hel-platform.docker.sh/fi/hero-taustakuva
- https://hel-platform.docker.sh/fi/node/7

Also check these PRs:
https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/34
https://github.com/City-of-Helsinki/drupal-hdbt/pull/42