### PR TITLE
UHF-1273: Add new image style 2.3:1 xxs and applied it to hero diagon…

### DIFF
--- a/conf/cmi/image.style.23_10_xxs.yml
+++ b/conf/cmi/image.style.23_10_xxs.yml
@@ -1,0 +1,17 @@
+uuid: ed0ac039-3eaa-41cb-9ba1-657109fa0ff9
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: 23_10_xxs
+label: '2.3:1 XXS'
+effects:
+  6e091026-4f44-46e3-a4ac-aef3e6e3571b:
+    uuid: 6e091026-4f44-46e3-a4ac-aef3e6e3571b
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 320
+      height: 139
+      crop_type: focal_point

--- a/conf/cmi/image.style.23_10_xxs_2x.yml
+++ b/conf/cmi/image.style.23_10_xxs_2x.yml
@@ -1,0 +1,24 @@
+uuid: 12c06b00-632e-4d3d-81b8-bd38a267417f
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+    - image_style_quality
+name: 23_10_xxs_2x
+label: '2.3:1 XXS (2X)'
+effects:
+  a9f4372f-0393-406a-b2e9-c388fd1374f1:
+    uuid: a9f4372f-0393-406a-b2e9-c388fd1374f1
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 640
+      height: 278
+      crop_type: focal_point
+  6c4d1aca-1b29-495e-8d33-cf39504feb5a:
+    uuid: 6c4d1aca-1b29-495e-8d33-cf39504feb5a
+    id: image_style_quality
+    weight: 2
+    data:
+      quality: 65

--- a/conf/cmi/responsive_image.styles.hero__bottom.yml
+++ b/conf/cmi/responsive_image.styles.hero__bottom.yml
@@ -13,6 +13,8 @@ dependencies:
     - image.style.23_10_xl_2x
     - image.style.23_10_xs
     - image.style.23_10_xs_2x
+    - image.style.23_10_xxs
+    - image.style.23_10_xxs_2x
   theme:
     - hdbt
 _core:
@@ -74,11 +76,11 @@ image_style_mappings:
     breakpoint_id: hdbt.xxs
     multiplier: 1x
     image_mapping_type: image_style
-    image_mapping: 23_10_xs
+    image_mapping: 23_10_xxs
   -
     breakpoint_id: hdbt.xxs
     multiplier: 2x
     image_mapping_type: image_style
-    image_mapping: 23_10_xs_2x
+    image_mapping: 23_10_xxs_2x
 breakpoint_group: hdbt
 fallback_image_style: 23_10_m

--- a/conf/cmi/responsive_image.styles.hero__diagonal.yml
+++ b/conf/cmi/responsive_image.styles.hero__diagonal.yml
@@ -11,6 +11,8 @@ dependencies:
     - image.style.23_10_s_2x
     - image.style.23_10_xs
     - image.style.23_10_xs_2x
+    - image.style.23_10_xxs
+    - image.style.23_10_xxs_2x
   theme:
     - hdbt
 _core:
@@ -62,11 +64,11 @@ image_style_mappings:
     breakpoint_id: hdbt.xxs
     multiplier: 1x
     image_mapping_type: image_style
-    image_mapping: 23_10_xs
+    image_mapping: 23_10_xxs
   -
     breakpoint_id: hdbt.xxs
     multiplier: 2x
     image_mapping_type: image_style
-    image_mapping: 23_10_xs_2x
+    image_mapping: 23_10_xxs_2x
 breakpoint_group: hdbt
 fallback_image_style: 23_10_m

--- a/conf/cmi/responsive_image.styles.hero__left_right.yml
+++ b/conf/cmi/responsive_image.styles.hero__left_right.yml
@@ -3,8 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.23_10_xs
-    - image.style.23_10_xs_2x
+    - image.style.23_10_xxs
+    - image.style.23_10_xxs_2x
     - image.style.3_2_s
     - image.style.3_2_s_2x
     - image.style.3_2_xs
@@ -40,11 +40,11 @@ image_style_mappings:
     breakpoint_id: hdbt.xxs
     multiplier: 1x
     image_mapping_type: image_style
-    image_mapping: 23_10_xs
+    image_mapping: 23_10_xxs
   -
     breakpoint_id: hdbt.xxs
     multiplier: 2x
     image_mapping_type: image_style
-    image_mapping: 23_10_xs_2x
+    image_mapping: 23_10_xxs_2x
 breakpoint_group: hdbt
 fallback_image_style: 3_2_s


### PR DESCRIPTION
…al, bottom. left and right

How to test:

1. `git fetch && git checkout UHF-1273-image-adjustments-for-unit-and-hero`
2. `composer require drupal/hdbt:dev-UHF-1273-image-adjustments-for-unit-and-hero && composer require drupal/helfi_platform_config:dev-UHF-1273-image-adjustments-for-unit-and-hero`
3. `make drush-cim && make drush-cr`
4. Go to create a unit node and add a picture for it (alternative or  for example `[aet:tpr_unit:51342:picture_url]`).
5. Resize browser to smaller size than 320px wide. The image aspect ratio should change to 2.3:1 from 3:2 that is used on larger screens. This is to unify how the image style works on hero (also on hero images I changed the 2.3:1 xs image size to new smaller and thus more applicaple 2.3:1 xxs size).

Check also these PRs:
https://github.com/City-of-Helsinki/drupal-hdbt/pull/72
https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/75