### PR TITLE
UHF-X Fix base config feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "cweagans/composer-patches": "^1.6.7",
         "drupal/admin_toolbar": "^2.4.0",
         "drupal/aet": "^2.0@alpha",
+        "drupal/config_replace": "^2.0",
         "drupal/core-composer-scaffold": "^9.0",
         "drupal/core-recommended": "^9.0",
         "drupal/diff": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "30a60981fb8c467b17df4a1ba7e362e1",
+    "content-hash": "d9e9878a3765ac04b7dd5789ade58863",
     "packages": [
         {
             "name": "City-of-Helsinki/php-hauki-client",
@@ -1803,6 +1803,54 @@
                 "issues": "https://github.com/druidfi/api_tools/issues"
             },
             "time": "2020-10-16T16:23:07+00:00"
+        },
+        {
+            "name": "drupal/config_replace",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_replace.git",
+                "reference": "2.0.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_replace-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "c2d468052cee1c05d3ac11cffd49d03853277dcf"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.2",
+                    "datestamp": "1600932402",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Peter Majmesku",
+                    "homepage": "https://www.drupal.org/user/786132"
+                },
+                {
+                    "name": "marcoliver",
+                    "homepage": "https://www.drupal.org/user/1529744"
+                }
+            ],
+            "description": "Replaces existing configuration on module installation via using a \"rewrite\" folder in the config directory.",
+            "homepage": "https://www.drupal.org/project/config_replace",
+            "support": {
+                "source": "https://git.drupalcode.org/project/config_replace"
+            }
         },
         {
             "name": "drupal/config_update",

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -9,6 +9,7 @@ module:
   breakpoint: 0
   ckeditor: 0
   config: 0
+  config_replace: 0
   config_translation: 0
   config_update: 0
   crop: 0


### PR DESCRIPTION
- Switch to corresponding branches: 
  - `composer require drupal/helfi_platform_config:dev-UHF-X-fix-base-config-feature`
- `make drush-cim && make drush-cr`
- Go to https://helfi.docker.sh/en/admin/config/development/features and revert all features that are changed.
- All features should now go to default state (except helfi_media because of the theme dependency that cannot be set).

Also check:
https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/76