### PR TITLE
UHF-1621: TPR custom URL alias (configurations)

### DIFF
--- a/conf/cmi/pathauto.pattern.service_entity_pattern.yml
+++ b/conf/cmi/pathauto.pattern.service_entity_pattern.yml
@@ -7,7 +7,7 @@ dependencies:
 id: service_entity_pattern
 label: 'Service entity pattern'
 type: 'canonical_entities:tpr_service'
-pattern: '[tpr_service:label]'
+pattern: '[tpr_service:menu-link-parents]/[tpr_service:label]'
 selection_criteria: {  }
 selection_logic: and
 weight: 0

--- a/conf/cmi/pathauto.pattern.unit_entity_pattern.yml
+++ b/conf/cmi/pathauto.pattern.unit_entity_pattern.yml
@@ -7,7 +7,7 @@ dependencies:
 id: unit_entity_pattern
 label: 'Unit entity pattern'
 type: 'canonical_entities:tpr_unit'
-pattern: '[tpr_unit:label]'
+pattern: '[tpr_unit:menu-link-parents]/[tpr_unit:label]'
 selection_criteria: {  }
 selection_logic: and
 weight: 0

--- a/conf/cmi/pathauto.settings.yml
+++ b/conf/cmi/pathauto.settings.yml
@@ -51,5 +51,6 @@ safe_tokens:
   - login-url
   - url
   - url-brief
+  - menu-link-parents
 _core:
   default_config_hash: SwvLp8snyPEExF41CaJJYdPUVomofLqtXvwciHc4cPg


### PR DESCRIPTION
Configuration changes that go along with https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/35.

How to test:
- get the changes both from the abovementioned PR and this one
- import configurations using `make shell` (to run in the container) and `drush cim`
- place some `tpr_unit` and `tpr_service` (`TPR - Toimipiste` and `TPR - Palvelu`, respectively) entities in a menu tree & enable automatic URL alias generation for the entities in question
- see how the generated URL alias reflects the menu structure