### PR TITLE
UHF-1775 Footer settings to config ignore

### DIFF
--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -1,4 +1,5 @@
 ignored_config_entities:
   - 'eu_cookie_compliance.cookie_category*'
+  - site_settings
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -1,5 +1,5 @@
 ignored_config_entities:
   - 'eu_cookie_compliance.cookie_category*'
-  - site_settings
+  - '*.site_settings'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/conf/cmi/hdbt_admin_tools.site_settings.yml
+++ b/conf/cmi/hdbt_admin_tools.site_settings.yml
@@ -1,13 +1,13 @@
 langcode: en
 footer_settings:
-  footer_color: dark
+  footer_color: light
   footer_top_title: 'Contact information'
   footer_top_content:
-    value: '<p><a href="#">Search for contacts and phone numbers</a></p><p><a href="#" class="hds-button hds-button--secondary"><span aria-hidden="true" class="hds-icon hds-icon--phone"></span><span class="hds-button__label">Helsinki-info 09 310 1691</span></a></p>'
+    value: "<p><a href=\"#\">Search for contacts and phone numbers</a></p>\r\n\r\n<p><a class=\"hds-button hds-button--secondary hdbt-icon hdbt-icon--phone\" data-design=\"hds-button hds-button--secondary\" data-icon=\"phone\" data-link-text=\"Helsinki-info 09 310 1691\" data-protocol=\"false\" href=\"#\"><span class=\"hds-button__label\">Helsinki-info 09 310 1691</span></a></p>\r\n"
     format: full_html
 _core:
   default_config_hash: eVdGTiXTp44lBBOWzgZiL_sNdnzTQmnFlR2PNQeh-XA
 site_settings:
   theme_color: coat-of-arms
   default_icon: home-smoke
-  koro: basic
+  koro: beat

--- a/conf/cmi/language/fi/hdbt_admin_tools.site_settings.yml
+++ b/conf/cmi/language/fi/hdbt_admin_tools.site_settings.yml
@@ -1,4 +1,5 @@
 footer_settings:
   footer_top_content:
-    value: '<p><a href="#">Hae yhteystietoja ja numeroita</a></p><p><a href="#" class="hds-button hds-button--secondary"><span aria-hidden="true" class="hds-icon hds-icon--phone"></span><span class="hds-button__label">Helsinki-info 09 310 1691</span></a></p>'
+    value: "<p><a href=\"#\">Hae yhteystietoja ja numeroita</a></p>\r\n\r\n<p><a class=\"hds-button hds-button--secondary hdbt-icon hdbt-icon--phone\" data-design=\"hds-button hds-button--secondary\" data-icon=\"phone\" data-link-text=\"Helsinki-info 09 310 1691\" data-protocol=\"false\" href=\"#\"><span class=\"hds-button__label\">Helsinki-info 09 310 1691</span></a></p>\r\n"
+    format: full_html
   footer_top_title: Yhteystiedot


### PR DESCRIPTION
To test assuming you have a site running on your local:

1. Change into this branch: `git checkout UHF-1775-footer-settings-to-config-ignore`
2. Import configuration changes: `make drush-cim`
3. Clear caches: `make drush-cr`
4. Go to https://helfi.docker.so/fi/admin/tools/site-settings and change a setting (for example write something new to the footer) and save the settings. Make sure the change you did to your footer is visible on the site (make sure you are viewing the site with the language that you made the change to.
5. Run `make drush-cim`
6. The configuration import shouldn't revert your changes and it should say that there is nothing to import.
7. Notice: if you EXPORT the changes that you made using `make drush-cex` they will still be exported and this is fine but naturally don't export any new changes to this PR :)

Also check these PRs:
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/31
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/40
https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/120