### PR TITLE
UHF-1734 Basic page changes

### DIFF
--- a/conf/cmi/core.entity_form_display.node.page.default.yml
+++ b/conf/cmi/core.entity_form_display.node.page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_has_hero
     - field.field.node.page.field_hero
+    - field.field.node.page.field_lead_in
     - field.field.node.page.field_liftup_image
     - field.field.node.page.field_lower_content
     - field.field.node.page.field_metatags
@@ -31,7 +32,7 @@ content:
     third_party_settings: {  }
   field_content:
     type: paragraphs
-    weight: 12
+    weight: 13
     region: content
     settings:
       title: Paragraph
@@ -74,16 +75,24 @@ content:
     third_party_settings: {  }
     type: paragraphs
     region: content
+  field_lead_in:
+    weight: 12
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
   field_liftup_image:
     type: media_library_widget
-    weight: 3
+    weight: 4
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   field_lower_content:
     type: paragraphs
-    weight: 52
+    weight: 19
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -101,7 +110,7 @@ content:
     third_party_settings: {  }
     region: content
   field_metatags:
-    weight: 51
+    weight: 18
     settings:
       sidebar: false
     third_party_settings: {  }
@@ -129,12 +138,12 @@ content:
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 20
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -177,12 +186,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.page.default.yml
+++ b/conf/cmi/core.entity_view_display.node.page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_has_hero
     - field.field.node.page.field_hero
+    - field.field.node.page.field_lead_in
     - field.field.node.page.field_liftup_image
     - field.field.node.page.field_lower_content
     - field.field.node.page.field_metatags
@@ -23,13 +24,20 @@ mode: default
 content:
   field_content:
     type: entity_reference_revisions_entity_view
-    weight: 1
+    weight: 2
     region: content
     label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
+  field_lead_in:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
   field_lower_content:
     type: entity_reference_revisions_entity_view
     weight: 4
@@ -40,7 +48,7 @@ content:
     third_party_settings: {  }
     region: content
   field_metatags:
-    weight: 2
+    weight: 3
     label: above
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.page.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.page.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_has_hero
     - field.field.node.page.field_hero
+    - field.field.node.page.field_lead_in
     - field.field.node.page.field_liftup_image
     - field.field.node.page.field_lower_content
     - field.field.node.page.field_metatags
@@ -33,6 +34,7 @@ hidden:
   field_content: true
   field_has_hero: true
   field_hero: true
+  field_lead_in: true
   field_lower_content: true
   field_metatags: true
   langcode: true

--- a/conf/cmi/field.field.node.page.field_lead_in.yml
+++ b/conf/cmi/field.field.node.page.field_lead_in.yml
@@ -1,0 +1,19 @@
+uuid: e11378c2-4567-49a4-a49e-11acc2a954a9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_lead_in
+    - node.type.page
+id: node.page.field_lead_in
+field_name: field_lead_in
+entity_type: node
+bundle: page
+label: Lead-in
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/conf/cmi/field.storage.node.field_lead_in.yml
+++ b/conf/cmi/field.storage.node.field_lead_in.yml
@@ -1,0 +1,19 @@
+uuid: be6a0f8b-961e-4b6f-b1b7-44a8d6e0329a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_lead_in
+field_name: field_lead_in
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language/fi/field.field.node.page.field_lead_in.yml
+++ b/conf/cmi/language/fi/field.field.node.page.field_lead_in.yml
@@ -1,0 +1,1 @@
+label: Johdanto

--- a/conf/cmi/metatag.metatag_defaults.node.yml
+++ b/conf/cmi/metatag.metatag_defaults.node.yml
@@ -9,6 +9,7 @@ label: Content
 tags:
   canonical_url: '[node:url]'
   content_language: '[node:langcode]'
+  description: '[node:field_lead_in]'
   title: '[node:title] | [site:name]'
   article_modified_time: '[node:created:html_datetime]'
   article_published_time: '[node:created:html_datetime]'


### PR DESCRIPTION
NOTICE: This should be tested and merged AFTER the https://github.com/City-of-Helsinki/drupal-hdbt/pull/124 is merged to avoid conflicts since this feature is partly based on the work done it that PR.

To test assuming you have a site running on your local:

1. Change into this branch: `git checkout UHF-1734-basic-page-changes`
2. Checkout the correct branches on modules and themes: `composer require drupal/helfi_platform_config:dev-UHF-1734-basic-page-changes && composer require drupal/hdbt:dev-UHF-1734-basic-page-changes`
3. Import configuration changes: `make drush-cim`
4. Clear caches: `make drush-cr`
5. Go to create / edit any basic page. There should now be new field "Lead-in" before the content areas. It should be plaintext field. Write something to the field and if you don't have any other content then add some like text paragraphs etc. Save the node and go view it.
6. The new lead-in paragraph should be right under the page title. It should have font size 20px and line height 32px.
7. The lead-in text should also be found from the page meta-data description visible in the page source on head-tag.
8. The content should now be aligned to left on all breakpoints (there used to be 96px margin on left on desktop sizes)
9. There should be sufficient spacing before titles, heros etc. There is a lot of small changes here but the main thing is that the layout doesn't look broken.

Also check these PRs:
https://github.com/City-of-Helsinki/drupal-hdbt/pull/125
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/43
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/34
https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/123