### PR TITLE
UHF-1410: Add service page configuration

### DIFF
--- a/conf/cmi/core.entity_view_display.tpr_errand_service.tpr_errand_service.default.yml
+++ b/conf/cmi/core.entity_view_display.tpr_errand_service.tpr_errand_service.default.yml
@@ -1,0 +1,118 @@
+uuid: e5d4131c-b015-47b9-b42d-40015c3f7424
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+    - link
+    - text
+id: tpr_errand_service.tpr_errand_service.default
+targetEntityType: tpr_errand_service
+bundle: tpr_errand_service
+mode: default
+content:
+  channels:
+    type: entity_reference_entity_view
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+  costs:
+    type: text_default
+    weight: 12
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  description:
+    type: text_default
+    weight: 1
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  expiration_time:
+    type: text_default
+    weight: 10
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  information:
+    type: text_default
+    weight: 11
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+      native_language: false
+    third_party_settings: {  }
+  links:
+    type: link
+    weight: 7
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+  name:
+    type: string
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  name_override:
+    type: string
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  name_synonyms:
+    type: string
+    weight: 6
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  process_description:
+    type: text_default
+    weight: 8
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  processing_time:
+    type: text_default
+    weight: 9
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  type:
+    type: string
+    weight: 5
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden: {  }

--- a/conf/cmi/core.entity_view_display.tpr_service.tpr_service.default.yml
+++ b/conf/cmi/core.entity_view_display.tpr_service.tpr_service.default.yml
@@ -4,11 +4,12 @@ status: true
 dependencies:
   config:
     - field.field.tpr_service.tpr_service.field_content
-    - field.field.tpr_service.tpr_service.field_metatags
     - field.field.tpr_service.tpr_service.field_lower_content
+    - field.field.tpr_service.tpr_service.field_metatags
   module:
     - entity_reference_revisions
     - helfi_tpr
+    - link
     - metatag
     - text
 _core:
@@ -24,6 +25,15 @@ content:
     region: content
     label: hidden
     settings: {  }
+    third_party_settings: {  }
+  errand_services:
+    type: entity_reference_entity_view
+    weight: 6
+    region: content
+    label: hidden
+    settings:
+      link: true
+      view_mode: default
     third_party_settings: {  }
   field_content:
     type: entity_reference_revisions_entity_view
@@ -50,6 +60,18 @@ content:
     third_party_settings: {  }
     type: metatag_empty_formatter
     region: content
+  links:
+    type: link
+    weight: 7
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
   name:
     type: string
     weight: 0
@@ -68,6 +90,4 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  errand_services: true
   langcode: true
-  links: true

--- a/conf/cmi/core.entity_view_display.tpr_service_channel.tpr_service_channel.default.yml
+++ b/conf/cmi/core.entity_view_display.tpr_service_channel.tpr_service_channel.default.yml
@@ -1,0 +1,220 @@
+uuid: 2b58b8fd-225b-4cc6-8a80-1ae3fbdb0058
+langcode: en
+status: true
+dependencies:
+  module:
+    - address
+    - helfi_tpr
+    - link
+    - telephone
+    - text
+id: tpr_service_channel.tpr_service_channel.default
+targetEntityType: tpr_service_channel
+bundle: tpr_service_channel
+mode: default
+content:
+  address:
+    type: address_default
+    weight: 12
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  authorization_code:
+    type: text_default
+    weight: 16
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  availabilities:
+    type: string
+    weight: 11
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  availability_summary:
+    type: text_default
+    weight: 13
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  call_charge_info:
+    type: text_default
+    weight: 17
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  e_decision:
+    type: boolean
+    weight: 20
+    region: content
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+  e_processing:
+    type: boolean
+    weight: 19
+    region: content
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+  email:
+    type: string
+    weight: 9
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  expiration_time:
+    type: text_default
+    weight: 15
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  for_corporate_customer:
+    type: boolean
+    weight: 23
+    region: content
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+  for_personal_customer:
+    type: boolean
+    weight: 22
+    region: content
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+  langcode:
+    type: language
+    weight: 5
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+      native_language: false
+    third_party_settings: {  }
+  links:
+    type: link
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+  name:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  name_override:
+    type: string
+    weight: 7
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  name_synonyms:
+    type: string
+    weight: 8
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  payment_enabled:
+    type: boolean
+    weight: 21
+    region: content
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+  phone:
+    type: telephone_link
+    weight: 10
+    region: content
+    label: hidden
+    settings:
+      title: ''
+    third_party_settings: {  }
+  prerequisites:
+    type: text_default
+    weight: 4
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  process_description:
+    type: text_default
+    weight: 14
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  requires_authentication:
+    type: boolean
+    weight: 6
+    region: content
+    label: hidden
+    settings:
+      format: default
+      format_custom_true: ''
+      format_custom_false: ''
+    third_party_settings: {  }
+  saved_to_customer_folder:
+    type: boolean
+    weight: 18
+    region: content
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+  type:
+    type: string
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  type_string:
+    type: string
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden: {  }


### PR DESCRIPTION
To test:

1. Checkout this branch and switch to corresponding branches: `composer require drupal/helfi_tpr:dev-UHF-1410_palvelusivu && composer require drupal/helfi_platform_config:dev-UHF-1410_palvelusivu`
2. Run `make drush-cr && make drush-cim && make drush-cr`
3. Make sure you have services, errand services and service channels imported from TPR. 
4. If you have them already just skip to part 11. If not run `make shell`
5. `drush en -y helfi_tpr_config`
6. Import some TPR entities (set `MIGRATE_LIMIT=500 `or similar if seen fit):
7. `drush migrate:import tpr_service`
8. `drush migrate:import tpr_errand_service`
9. `drush migrate:import tpr_service_channel`
10. `drush cr` Now you should have some services and errand services and service channels.
11. Go to view a service - for example: https://helfi.docker.so/fi/asukaspysakointi It should now have errand services and service channels visible.
