### PR TITLE
Default content entity normalizer fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,9 @@
                 "https://www.drupal.org/project/drupal/issues/2845437#comment-13784958": "https://www.drupal.org/files/issues/2020-08-12/2845437-32.patch",
                 "[#UHF-949] Drupal.views.ajaxView is not initializing pagers in nested views (https://www.drupal.org/project/drupal/issues/2858890).": "https://www.drupal.org/files/issues/2020-11-29/2858890-58.patch"
             },
+            "drupal/default_content": {
+                "Manually fix object handling in Content entity normalizer.": "./patches/default_content_object_support_disabled.patch"
+            },
             "drupal/features": {
                 "https://www.drupal.org/project/features/issues/2869336": "https://www.drupal.org/files/issues/features_export-config-translation-2869336-2.patch",
                 "https://www.drupal.org/project/features/issues/3034826": "https://www.drupal.org/files/issues/2021-03-31/features-call_to_member_function_on_null-3034826-5.patch"

--- a/patches/default_content_object_support_disabled.patch
+++ b/patches/default_content_object_support_disabled.patch
@@ -1,0 +1,28 @@
+diff --git a/src/Normalizer/ContentEntityNormalizer.php b/src/Normalizer/ContentEntityNormalizer.php
+index 9a303fa..12dccff 100644
+--- a/src/Normalizer/ContentEntityNormalizer.php
++++ b/src/Normalizer/ContentEntityNormalizer.php
+@@ -194,7 +194,12 @@ class ContentEntityNormalizer implements ContentEntityNormalizerInterface {
+     if (!empty($data['translations'])) {
+       foreach ($data['translations'] as $langcode => $translation_data) {
+         if ($this->languageManager->getLanguage($langcode)) {
+-          $translation = $entity->addTranslation($langcode, $entity->toArray());
++          if (!$entity->hasTranslation($langcode)) {
++            $translation = $entity->addTranslation($langcode, $entity->toArray());
++          }
++          else {
++            $translation = $entity->getTranslation($langcode, $entity->toArray());
++          }
+           foreach ($translation_data as $field_name => $values) {
+             $this->setFieldValues($translation, $field_name, $values);
+           }
+@@ -360,7 +365,8 @@ class ContentEntityNormalizer implements ContentEntityNormalizerInterface {
+           foreach ($field_item->getProperties(TRUE) as $property_name => $property) {
+             $value = $this->getValueFromProperty($property, $field_item, $translation_normalization[$field_name][$delta]);
+ 
+-            if ($value !== NULL) {
++            // Do not try to normalize objects.
++            if ($value !== NULL && !is_object($value)) {
+               if (is_string($value) && in_array($property_name, $serialized_property_names)) {
+                 $value = unserialize($value);
+               }


### PR DESCRIPTION
How to test:
1. Get the HELfi (helfi.docker.so) environment up and running
2. Checkout this branch. `git fetch && git checkout UHF-X_default_content_export_fix`
3. Run `make composer-install drush-cr`
4. Run `make shell`
5. Make sure that the HELfi example content module is installed. `drush en -y helfi_example_content`
6. In `/app/public` run `drush dcer node 8 --folder=modules/contrib/helfi_platform_config/helfi_features/helfi_example_content/content` where `node` is the entity to be exported and `8` is the id of that entity
7. Check the `/app/public/modules/contrib/helfi_platform_config/helfi_features/helfi_example_content/content` for changed/updated content